### PR TITLE
webui: ec2 - diet for key creation rest-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *__pycache__*
 env/
 tags
-webui/ec2/provider_conf.py
+webui/db.sqlite3

--- a/webui/ec2/EC2.py
+++ b/webui/ec2/EC2.py
@@ -2,8 +2,7 @@ from . import provider_conf
 from .models import User, AccessKey
 import boto3
 from botocore.exceptions import ClientError
-import datetime
-import re
+
 
 def _ec2user_to_user(ec2user):
     u = User()
@@ -12,6 +11,7 @@ def _ec2user_to_user(ec2user):
     u.create_date = ec2user.get('CreateDate')
     u.keys = []
     return u
+
 
 def _user_add_keys(user):
     iam = boto3.client('iam', aws_access_key_id=provider_conf.EC2['key'],
@@ -23,78 +23,119 @@ def _user_add_keys(user):
             k.create_date = key.get('CreateDate')
             k.key_id = key.get('AccessKeyId')
             k.status = key.get('Status').lower()
-            user.keys.append(k);
+            user.keys.append(k)
     return user
 
 
-def get_users(name = None):
+def get_users(name=None):
     '''
-    See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html
-    for more details on boto iam api.
+    See for more details on boto iam api.
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html
     '''
     iam = boto3.client('iam', aws_access_key_id=provider_conf.EC2['key'],
                        aws_secret_access_key=provider_conf.EC2['secret'])
     users = []
-    if (name):
+    if name:
         try:
-            response = iam.get_user(UserName = name)
+            response = iam.get_user(UserName=name)
             user = response.get('User')
-            u = _ec2user_to_user(user);
-            _user_add_keys(u);
-            users.append(u);
+            u = _ec2user_to_user(user)
+            _user_add_keys(u)
+            users.append(u)
         except ClientError as ex:
-            print (ex);
+            print(ex)
     else:
         for response in iam.get_paginator('list_users').paginate():
             for user in response.get('Users'):
-                u = _ec2user_to_user(user);
-                _user_add_keys(u);
-                users.append(u);
+                u = _ec2user_to_user(user)
+                _user_add_keys(u)
+                users.append(u)
 
-    return users;
+    return users
+
+
+def get_user_by_key(key_id):
+    users = get_users()
+
+    for user in users:
+        for key in user.keys:
+            if key_id == key.key_id:
+                return user
+    return None
+
+
+def get_key(key_id):
+    users = get_users()
+    for user in users:
+        for key in user.keys:
+            if key_id == key.key_id:
+                return key
+    return None
+
+
+def delete_key(key_id):
+    user = get_user_by_key(key_id)
+    if user is None:
+        return False
+    if len(user.keys) == 1:
+        delete_user(user.name)
+        return True
+    else:
+        iam_res = boto3.resource(
+            'iam', aws_access_key_id=provider_conf.EC2['key'],
+            aws_secret_access_key=provider_conf.EC2['secret'])
+        key = iam_res.AccessKey(user.name, key_id)
+        key.delete()
+        return True
 
 
 def delete_user(username):
     iam = boto3.client('iam', aws_access_key_id=provider_conf.EC2['key'],
                        aws_secret_access_key=provider_conf.EC2['secret'])
     iam_res = boto3.resource('iam', aws_access_key_id=provider_conf.EC2['key'],
-                       aws_secret_access_key=provider_conf.EC2['secret'])
+                             aws_secret_access_key=provider_conf.EC2['secret'])
 
-    user = iam_res.User(username)
-    user.load()
+    try:
+        user = iam_res.User(username)
+        user.load()
+    except iam.meta.client.exceptions.NoSuchEntityException:
+        return False
 
     for key in user.access_keys.all():
         key.delete()
 
-    for response in iam.get_paginator('list_attached_user_policies').paginate(UserName = username):
+    for response in iam.get_paginator('list_attached_user_policies').paginate(
+            UserName=username):
         for policy in response.get('AttachedPolicies'):
-            user.detach_policy(PolicyArn = policy.get('PolicyArn'))
+            user.detach_policy(PolicyArn=policy.get('PolicyArn'))
     user.delete()
+    return True
+
 
 def create_user(username):
     iam_res = boto3.resource('iam', aws_access_key_id=provider_conf.EC2['key'],
-                       aws_secret_access_key=provider_conf.EC2['secret'])
+                             aws_secret_access_key=provider_conf.EC2['secret'])
     user = iam_res.User(username)
     try:
         user.load()
-    except ClientError:
+    except iam_res.meta.client.exceptions.NoSuchEntityException:
         try:
             user.create(Path="/pcw/auto-generated/")
-        except ClientError as err:
+        except ClientError:
             return None
 
         user.attach_policy(
-            PolicyArn='arn:aws:iam::aws:policy/AmazonEC2FullAccess'
+              PolicyArn='arn:aws:iam::aws:policy/AmazonEC2FullAccess'
         )
 
     try:
         key = user.create_access_key_pair()
-    except ClientError as err:
+    except ClientError:
         return None
 
     u = User()
-    u.name = user.user_name;
-    u.id = user.user_id;
+    u.name = user.user_name
+    u.id = user.user_id
     u.create_date = user.create_date
     k = AccessKey()
     k.create_date = key.create_date
@@ -103,4 +144,3 @@ def create_user(username):
     k.secret = key.secret
     u.keys = [k]
     return u
-

--- a/webui/ec2/provider_conf.py
+++ b/webui/ec2/provider_conf.py
@@ -1,5 +1,6 @@
 
 EC2 = {
+        'username_pattern': 'tmp_{}_openqa.suse.de',
         'key': 'AWS_ACCESS_KEY_ID',
         'secret': 'AWS_SECRET_ACCESS_KEY',
     }

--- a/webui/ec2/urls.py
+++ b/webui/ec2/urls.py
@@ -5,4 +5,6 @@ from . import views
 urlpatterns = [
     path('users', views.UserView.as_view()),
     path('users/<str:name>', views.UserView.as_view()),
+    path('key', views.AccessKeyView.as_view()),
+    path('key/<str:key_id>', views.AccessKeyView.as_view()),
 ]

--- a/webui/ec2/views.py
+++ b/webui/ec2/views.py
@@ -1,35 +1,65 @@
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden, HttpResponseServerError
+from django.http import HttpResponseNotFound
 from rest_framework.response import Response
-from ec2.serializers import UserSerializer
-from rest_framework import viewsets
+from ec2.serializers import UserSerializer, AccessKeySerializer
 from rest_framework import views
-from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated
-from . import EC2
+from . import EC2, provider_conf
 import re
 import time
 
+
 class UserView (views.APIView):
     authentication_classes = (SessionAuthentication, BasicAuthentication)
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated)
 
-    def get(self, request, name = None):
+    def get(self, request, name=None):
         yourdata = EC2.get_users(name)
         results = UserSerializer(yourdata, many=True).data
         return Response(results)
 
     def delete(self, request, name):
         # Allow only tmp users to be deleted
-        p = re.compile('^tmp_\d+_openqa.suse.de$')
+        p = re.compile('^{}$'.format(
+            provider_conf.EC2['username_pattern'].replace('{}', '\\d+')))
         if not p.match(name):
             return HttpResponseForbidden()
 
-        EC2.delete_user(name)
-        return Response("OK");
+        if EC2.delete_user(name):
+            return Response('OK')
+        else:
+            return HttpResponseNotFound()
 
     def post(self, request):
-        name = "tmp_{}_openqa.suse.de".format(int(time.time()));
+        name = provider_conf.EC2['username_pattern'].format(int(time.time()))
         yourdata = EC2.create_user(name)
         results = UserSerializer(yourdata).data
         return Response(results)
 
+
+class AccessKeyView (views.APIView):
+    authentication_classes = (SessionAuthentication, BasicAuthentication)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, key_id):
+        key = EC2.get_key(key_id)
+        if key:
+            return Response(AccessKeySerializer(key).data)
+        else:
+            return HttpResponseNotFound()
+
+    def delete(self, request, key_id):
+        if EC2.delete_key(key_id):
+            return Response('OK')
+        else:
+            return HttpResponseNotFound()
+
+    def post(self, request):
+        name = provider_conf.EC2['username_pattern'].format(int(time.time()))
+        user = EC2.create_user(name)
+        for key in user.keys:
+            if key.secret is not None:
+                return Response(AccessKeySerializer(key).data)
+        return HttpResponseServerError()


### PR DESCRIPTION
Avoid overhead of user creation when only a KEY_ID and a SECRET is
needed.
Keep Users api, as it is helpful to debug current status.

Some format changes, to be pep8 conform on changed files.