### PR TITLE
Fix BasePermissionMetaclass object is not iterable

### DIFF
--- a/webui/ec2/views.py
+++ b/webui/ec2/views.py
@@ -13,7 +13,7 @@ import time
 
 class UserView (views.APIView):
     authentication_classes = (SessionAuthentication, BasicAuthentication)
-    permission_classes = (IsAuthenticated)
+    permission_classes = (IsAuthenticated,)
 
     def get(self, request, name=None):
         yourdata = EC2.get_users(name)


### PR DESCRIPTION
Retrieve the TypeError:
  'BasePermissionMetaclass' object is not iterable

This happen cause the permission_classes isn't treated as list, without
following comma.

See similar issue: https://stackoverflow.com/questions/53649252/django-rest-framework-basepermissionmetaclass-object-is-not-iterable