### PR TITLE
Show only openqa instances by default.

### DIFF
--- a/webui/ocw/tables.py
+++ b/webui/ocw/tables.py
@@ -48,7 +48,7 @@ class InstanceFilter(BaseFilterSet):
                                                 initial=[str(i) for i in [StateChoice.ACTIVE, StateChoice.DELETING]])
     region = django_filters.CharFilter(lookup_expr='icontains')
     instance_id = django_filters.CharFilter(lookup_expr='icontains', field_name='instance_id')
-    csp_info = django_filters.CharFilter(lookup_expr='icontains', field_name='csp_info')
+    csp_info = django_filters.CharFilter(lookup_expr='icontains', field_name='csp_info', initial='openqa_created_by')
 
     class Meta:
         model = Instance


### PR DESCRIPTION
We search for the keyword openqa_created_by in csp_info.
This should exists as a TAG for each instances which was created by
openqa.