### PR TITLE
Introduce vault response caching for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ url = https://publiccloud.your.vault.server/vault
 user = Your_VAULT_USER
 password = VAULT_USER_PASSWORD
 namespaces = VAULT_NAMESPACE, VAULT_NAMESPACE_2, ...
+# Use this option only during development! When enabled last response from
+# vault is stored in a file 'auth.json'. The file is located in '/tmp/pcw'
+use-file-cache = False
 
 [vault.namespace.XXX]
 # XXX is the name of a namespace given in vault.namespaces

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
             'oauth2client',
             'google-api-python-client',
             'google-cloud-storage',
+            'python-dateutil',
             ],
 )

--- a/webui/ocw/lib/EC2.py
+++ b/webui/ocw/lib/EC2.py
@@ -23,7 +23,7 @@ class EC2:
         return EC2.__instances[vault_namespace]
 
     def check_credentials(self):
-        if self.__credentials.isExpired():
+        if self.__credentials.isValid():
             self.__credentials.renew()
             self.__key = None
             self.__secret = None
@@ -39,7 +39,7 @@ class EC2:
                 return True
             except Exception:
                 self.__logging.info("check_credentials (attemp:%d) with key %s expiring at %s ",
-                                    i, self.__key, self.__credentials.auth_expire)
+                                    i, self.__key, self.__credentials.getAuthExpire())
                 time.sleep(1)
         self.list_regions()
 

--- a/webui/ocw/lib/azure.py
+++ b/webui/ocw/lib/azure.py
@@ -28,7 +28,7 @@ class Azure:
         return self.__credentials.getData('subscription_id')
 
     def check_credentials(self):
-        if self.__credentials.isExpired():
+        if self.__credentials.isValid():
             self.__sp_credentials = None
             self.__credentials.renew()
 
@@ -38,7 +38,8 @@ class Azure:
                 return True
             except AuthenticationError:
                 self.__logger.info("check_credentials failed (attemp:%d) - for client_id %s should expire at %s",
-                                   i, self.__credentials.getData('client_id'), self.__credentials.auth_expire)
+                                   i, self.__credentials.getData('client_id'),
+                                   self.__credentials.getAuthExpire())
                 time.sleep(1)
         raise AuthenticationError("Invalid Azure credentials")
 

--- a/webui/ocw/lib/gce.py
+++ b/webui/ocw/lib/gce.py
@@ -16,7 +16,7 @@ class GCE:
         return GCE.__instances[vault_namespace]
 
     def compute_client(self):
-        if self.__credentials.isExpired():
+        if self.__credentials.isValid():
             self.__credentials.renew()
             self.__compute_clinet = None
         self.__project = self.__credentials.getPrivateKeyData()['project_id']

--- a/webui/webui/settings.py
+++ b/webui/webui/settings.py
@@ -1,4 +1,5 @@
 import configparser
+import re
 
 """
 Django settings for webui project.
@@ -196,6 +197,10 @@ class ConfigFile:
 
     def getList(self, name, default=[]):
         return [i.strip() for i in self.get(name, ','.join(default)).split(',')]
+
+    def getBoolean(self, name, default=False):
+        value = self.get(name, default)
+        return re.match('^(?i)(true|on|1|yes)$', value)
 
     def has(self, name):
         try:


### PR DESCRIPTION
When we get new credentials from vault, it takes some time (depending on
CSP) till these get valid on CSP side. To avoid this waiting period and
avoiding of creation from unnecessary many credentials, you could set the
vault.use_cache_file=True option in pcw.ini.