### PR TITLE
Cleanup images on Azure CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ namespaces = VAULT_NAMESPACE, VAULT_NAMESPACE_2, ...
 
 [vault.namespace.XXX]
 # XXX is the name of a namespace given in vault.namespaces
-# provider should be ec2, azure or csp
+# provider should be ec2, azure or gcp
 providers = csp1[, csp2]...
 
 [ec2]
@@ -59,6 +59,18 @@ age-hours = NUMBER_OF_HOURS_TO_COUNT_AS_LEFT_OVER
 # Optional section to set a specific receiver of left over notifications for
 # a defined vault namespace. XXX should be replaced with the vault namespace
 to = RECEIPE_ADDRESS_NS_1[, RECEIPE_ADDRESS_NS_2]
+
+
+[cleanup]
+# Specifiy how many images per flavor get keept
+max-images-per-flavor = 1
+# Max age of an image file
+max-images-age-hours = 744
+
+[cleanup.namespace.XXX]
+azure-storage-resourcegroup=openqa-upload
+azure-storage-account-name=openqa
+
 EOT
 
 python manage.py migrate

--- a/webui/ocw/lib/azure.py
+++ b/webui/ocw/lib/azure.py
@@ -1,8 +1,16 @@
 from ..lib.vault import AzureCredential
+from webui.settings import ConfigFile
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.storage import StorageManagementClient
+from azure.storage.blob import BlockBlobService
 from msrest.exceptions import AuthenticationError
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from distutils.version import LooseVersion
+import re
 import time
 import logging
 
@@ -70,3 +78,86 @@ class Azure:
 
     def delete_resource(self, resource_id):
         return self.resource_mgmt_client().resource_groups.delete(resource_id)
+
+    def cleanup_all(self):
+        ''' Cleanup all autodateed data which might created during automated tests.'''
+        cfg = ConfigFile()
+        resourcegroup = cfg.get(
+                ['cleanup.namespace.{}'.format(self.__credentials.namespace), 'azure-storage-resourcegroup'],
+                cfg.get(['cleanup', 'azure-storage-resourcegroup'], 'openqa-upload'))
+        storage_account = cfg.get(
+                ['cleanup.namespace.{}'.format(self.__credentials.namespace), 'azure-storage-account-name'],
+                cfg.get(['cleanup', 'azure-storage-account-name'], 'openqa'))
+        storage_client = StorageManagementClient(self.sp_credentials(), self.subscription())
+        storage_keys = storage_client.storage_accounts.list_keys(resourcegroup, storage_account)
+        storage_keys = [v.value for v in storage_keys.keys]
+        block_blob_service = BlockBlobService(account_name='openqa', account_key=storage_keys[0])
+
+        containers = block_blob_service.list_containers()
+        for c in containers:
+            self.__logger.debug('Found container {}'.format(c.name))
+            if (re.match('^bootdiagnostics-', c.name)):
+                self.cleanup_bootdiagnostics_container(block_blob_service, c)
+            if (c.name == 'sle-images'):
+                self.cleanup_sle_images_container(block_blob_service, c)
+
+    def cleanup_bootdiagnostics_container(self, bbsrv, container):
+        timeout = datetime.now(timezone.utc) + timedelta(seconds=60*60*24)
+        last_modified = container.properties.last_modified
+        generator = bbsrv.list_blobs(container.name)
+        for blob in generator:
+            if (last_modified < blob.properties.last_modified):
+                last_modified = blob.properties.last_modified
+        if (timeout > last_modified):
+            self.__logger.info("[Azure] Delete container {}".format(container.name))
+            if not bbsrv.delete_container(container.name):
+                self.__logger.error("Failed to delete container {}".format(container.name))
+
+    def cleanup_sle_images_container(self, bbsrv, container):
+        generator = bbsrv.list_blobs(container.name)
+        images = dict()
+        for img in generator:
+            self.__logger.debug('Found image {}'.format(img.name))
+            # SLES12-SP5-Azure.x86_64-0.9.1-SAP-BYOS-Build3.3.vhd
+            regex = re.compile(r"""
+                               SLES
+                               (?P<version>\d+(-SP\d+)?)
+                               -Azure\.
+                               (?P<arch>[^-]+)
+                               -
+                               (?P<kiwi>\d+\.\d+\.\d+)
+                               -
+                               (?P<flavor>[-\w]+)
+                               -
+                               Build(?P<build>\d+\.\d+)
+                               \.vhd
+                               """,
+                               re.X)
+            m = re.match(regex, img.name)
+            if (m):
+                key = '-'.join([m.group('version'), m.group('flavor'), m.group('arch')])
+                if key not in images:
+                    images[key] = list()
+
+                images[key].append({
+                        'build': "-".join([m.group('kiwi'), m.group('build')]),
+                        'name': img.name,
+                        'last_modified': img.properties.last_modified,
+                        })
+            else:
+                self.__logger.error("Unable to parse image name '{}'".format(img.name))
+
+        for key in images:
+            images[key].sort(key=lambda x: LooseVersion(x['build']))
+
+        cfg = ConfigFile()
+        self.url = cfg.get(['vault', 'url'])
+        max_images_per_flavor = cfg.get(['cleanup', 'max-images-per-flavor'], 1)
+        max_images_age_hours = cfg.get(['cleanup', 'max-images-age-hours'], 24 * 31)
+        for img_list in images.values():
+            for i in range(0, len(img_list)):
+                img = img_list[i]
+                if i < len(img_list) - max_images_per_flavor \
+                        or img['last_modified'] < datetime.now(timezone.utc) - timedelta(hours=max_images_age_hours):
+                    self.__logger.info("[Azure] Delete image '{}'".format(img['name']))
+                    bbsrv.delete_blob(container.name, img['name'], snapshot=None)

--- a/webui/ocw/lib/db.py
+++ b/webui/ocw/lib/db.py
@@ -178,6 +178,7 @@ def __update_run():
                 instances = [azure_to_local_instance(i, vault_namespace) for i in instances]
                 logger.info("Got %d resources groups from Azure", len(instances))
                 sync_csp_to_local_db(instances, ProviderChoice.AZURE, vault_namespace)
+                Azure(vault_namespace).cleanup_all()
 
             if 'ec2' in providers:
                 instances = []


### PR DESCRIPTION
Find and delete outdated images on Azure.
Add new configuration section `[cleanup]` this can contain:
```
max-images-per-flavor
max-images-age-hours
azure-storage-account-name
azure-storage-resourcegroup
```

The later two can be specified in a namespace specific subgroup named
`[cleanup.namespace.XXX]`.
This is needed as the storage-account is a worlwide unique name.