### PR TITLE
 Add GCE image cleanup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use-file-cache = False
 
 [vault.namespace.XXX]
 # XXX is the name of a namespace given in vault.namespaces
-# provider should be ec2, azure or csp
+# provider should be ec2, azure or gcp
 providers = csp1[, csp2]...
 
 [ec2]
@@ -62,6 +62,18 @@ age-hours = NUMBER_OF_HOURS_TO_COUNT_AS_LEFT_OVER
 # Optional section to set a specific receiver of left over notifications for
 # a defined vault namespace. XXX should be replaced with the vault namespace
 to = RECEIPE_ADDRESS_NS_1[, RECEIPE_ADDRESS_NS_2]
+
+
+[cleanup]
+# Specifiy how many images per flavor get keept
+max-images-per-flavor = 1
+# Max age of an image file
+max-images-age-hours = 744
+
+[cleanup.namespace.XXX]
+azure-storage-resourcegroup=openqa-upload
+azure-storage-account-name=openqa
+
 EOT
 
 python manage.py migrate

--- a/webui/ocw/lib/db.py
+++ b/webui/ocw/lib/db.py
@@ -178,6 +178,7 @@ def __update_run():
                 instances = [azure_to_local_instance(i, vault_namespace) for i in instances]
                 logger.info("Got %d resources groups from Azure", len(instances))
                 sync_csp_to_local_db(instances, ProviderChoice.AZURE, vault_namespace)
+                Azure(vault_namespace).cleanup_all()
 
             if 'ec2' in providers:
                 instances = []

--- a/webui/ocw/lib/db.py
+++ b/webui/ocw/lib/db.py
@@ -193,6 +193,7 @@ def __update_run():
                 instances = [gce_to_local_instance(i, vault_namespace) for i in instances]
                 logger.info("Got %d instances from GCE", len(instances))
                 sync_csp_to_local_db(instances, ProviderChoice.GCE, vault_namespace)
+                GCE(vault_namespace).cleanup_all()
 
             with update_mutex:
                 update_date = timezone.now()

--- a/webui/ocw/lib/gce.py
+++ b/webui/ocw/lib/gce.py
@@ -1,12 +1,22 @@
 from .vault import GCECredential
+from .provider import Provider
 import googleapiclient.discovery
 from google.oauth2 import service_account
+from dateutil.parser import parse
+import re
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import logging
+from distutils.version import LooseVersion
+
+logger = logging.getLogger(__name__)
 
 
-class GCE:
+class GCE(Provider):
     __instances = dict()
     __credentials = None
-    __compute_clinet = None
+    __compute_client = None
     __project = None
 
     def __new__(cls, vault_namespace):
@@ -18,12 +28,13 @@ class GCE:
     def compute_client(self):
         if self.__credentials.isValid():
             self.__credentials.renew()
-            self.__compute_clinet = None
+            self.__compute_client = None
         self.__project = self.__credentials.getPrivateKeyData()['project_id']
-        if(self.__compute_clinet is None):
+        if(self.__compute_client is None):
             credentials = service_account.Credentials.from_service_account_info(self.__credentials.getPrivateKeyData())
-            self.__compute_clinet = googleapiclient.discovery.build('compute', 'v1', credentials=credentials)
-        return self.__compute_clinet
+            self.__compute_client = googleapiclient.discovery.build('compute', 'v1', credentials=credentials,
+                                                                    cache_discovery=False)
+        return self.__compute_client
 
     def list_instances(self, zone):
         ''' List all instances by zone.'''
@@ -66,3 +77,59 @@ class GCE:
     @staticmethod
     def url_to_name(url):
         return url[url.rindex('/')+1:]
+
+    def cleanup_all(self):
+        images = dict()
+        request = self.compute_client().images().list(project=self.__project)
+        while request is not None:
+            response = request.execute()
+            for image in response['items']:
+                logger.debug('Found image {}'.format(image['name']))
+                # creation:2019-11-04T14:23:06.372-08:00
+                # name:sles12-sp5-gce-x8664-0-9-1-byos-build1-56
+                regex = re.compile(r'''^sles
+                            (?P<version>\d+(-sp\d+)?)
+                            -gce-
+                            (?P<arch>[^-]+)
+                            -
+                            (?P<kiwi>\d+-\d+-\d+)
+                            -
+                            (?P<flavor>(byos|on-demand))
+                            -build
+                            (?P<build>\d+-\d+)
+                            ''', re.RegexFlag.X)
+                m = re.match(regex, image['name'])
+                if m:
+                    key = '-'.join([m.group('version'), m.group('flavor'), m.group('arch')])
+                    if key not in images:
+                        images[key] = list()
+
+                    images[key].append({
+                        'build': "-".join([m.group('kiwi'), m.group('build')]),
+                        'name': image['name'],
+                        'creation_datetime':  parse(image['creationTimestamp']),
+                        })
+                else:
+                    logger.error("Unable to parse image name '{}'".format(image['name']))
+
+            request = self.compute_client().images().list_next(previous_request=request, previous_response=response)
+
+        for key in images:
+            images[key].sort(key=lambda x: LooseVersion(x['build']))
+
+        max_images_per_flavor = self.cfgGet('cleanup', 'max-images-per-flavor')
+        max_images_age_hours = self.cfgGet('cleanup', 'max-images-age-hours')
+        dead_line = datetime.now(timezone.utc) - timedelta(hours=max_images_age_hours)
+        for img_list in images.values():
+            for i in range(0, len(img_list)):
+                img = img_list[i]
+                if i < len(img_list) - max_images_per_flavor or img['creation_datetime'] < dead_line:
+                    logger.info("[GCE] Delete image '{}'".format(img['name']))
+                    request = self.compute_client().images().delete(project=self.__project, image=img['name'])
+                    response = request.execute()
+                    if 'error' in response:
+                        for e in response['error']['errors']:
+                            logger.error(e['message'])
+                    if 'warnings' in response:
+                        for w in response['warnings']:
+                            logger.error(w['message'])


### PR DESCRIPTION
We use the same configuration behavior as for Azure!
`cleanup/max-images-per-flavor` and `cleanup/max-images-age-hours` which can be namespace configured by changing the section from 'cleanup' to `cleanup.namespace.XXX`
    
For common code between different providers I introduced super class `ocw.lib.provider.Provider`.


DO NOT MERGE BEFORE https://github.com/cfconrad/pcw/pull/41