### PR TITLE
Enable cleanup by namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ to = RECEIPE_ADDRESS_NS_1[, RECEIPE_ADDRESS_NS_2]
 
 
 [cleanup]
+# Specify with which namespace, we will do the cleanup. By default it is the
+# same list as defined with [vault]->namespaces
+namespaces = VAULT_NAMESPACE, VAULT_NAMESPACE_2, ...
 # Specify how many images per flavor get kept
 max-images-per-flavor = 1
 # Max age of an image file

--- a/ocw/lib/cleanup.py
+++ b/ocw/lib/cleanup.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def cleanup_run():
     cfg = ConfigFile()
-    for vault_namespace in cfg.getList(['vault', 'namespaces'], ['']):
+    for vault_namespace in cfg.getList(['cleanup', 'namespaces'], cfg.getList(['vault', 'namespaces'], [''])):
         try:
             providers = cfg.getList(['vault.namespace.{}'.format(vault_namespace), 'providers'],
                                     ['ec2', 'azure', 'gce'])


### PR DESCRIPTION
This patch allow the to enable/disable cleanup functionallity by
namespace.
By default, cleanup is enabled for the same namespaces as specified with
`[vault]->namespaces`.