### PR TITLE
Update bootstrap3 to bootstrap4

### DIFF
--- a/ocw/templates/base.html
+++ b/ocw/templates/base.html
@@ -1,5 +1,5 @@
 {% load static %}
-{% load bootstrap3 %}
+{% load bootstrap4 %}
 <html>
     <head>
         <title>OpenQA-CloudWatch</title>
@@ -22,10 +22,10 @@
             <div class="col-sm-6">
               <div class="small-info"></div>
               <ul class="list-inline" style="float:right;">
-                <li>
+                <li class="list-inline-item">
                 <div id="check_update_running"></div>
                 </li>
-                <li>
+                <li class="list-inline-item">
               {% if user.is_authenticated %}
                   <form method="post" action="{% url 'logout' %}">
                   {% csrf_token %}

--- a/ocw/templates/ocw/instance_list.html
+++ b/ocw/templates/ocw/instance_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load render_table from django_tables2 %}
 {% load static %}
-{% load bootstrap3 %}
+{% load bootstrap4 %}
 
 {% block content %}
     <link rel="stylesheet" href="{% static 'css/instance_table.css' %}">

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests
 django
 django-tables2
 django-filter
-django-bootstrap3
+django-bootstrap4
 texttable
 oauth2client
 google-api-python-client

--- a/webui/settings.py
+++ b/webui/settings.py
@@ -47,7 +47,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_tables2',
     'django_filters',
-    'bootstrap3',
+    'bootstrap4',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
It looks like bootstrap3[1] was only supported with version Django2 with
Django3 I discovered problems like:

```
File "/usr/local/lib/python3.8/site-packages/bootstrap3/utils.py", line 7, in <module>
  from django.utils import six
ImportError: cannot import name 'six' from 'django.utils' (/usr/local/lib/python3.8/site-packages/django/utils/__init__.py)
```

This patch moves to bootstrap4[2]

[1] https://pypi.org/project/django-bootstrap3/
[2] https://pypi.org/project/django-bootstrap4/