### PR TITLE
gce: Fix cleanup if no images are listed in response

### DIFF
--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -82,6 +82,8 @@ class GCE(Provider):
         request = self.compute_client().images().list(project=self.__project)
         while request is not None:
             response = request.execute()
+            if 'items' not in response:
+                break
             for image in response['items']:
                 logger.debug('Found image {}'.format(image['name']))
                 # creation:2019-11-04T14:23:06.372-08:00


### PR DESCRIPTION
We got a exception on gce cleanup
```
  File "./ocw/lib/gce.py", line 85, in cleanup_all
    for image in response['items']:
  KeyError: 'items'
```
This fix this issue.