### PR TITLE
Fix: timedelta() expect int for hours value

### DIFF
--- a/ocw/lib/EC2.py
+++ b/ocw/lib/EC2.py
@@ -113,7 +113,8 @@ class EC2(Provider):
             images[key].sort(key=lambda x: LooseVersion(x['build']))
 
         max_images_per_flavor = self.cfgGet('cleanup', 'max-images-per-flavor')
-        max_images_age = datetime.now(timezone.utc) - timedelta(hours=self.cfgGet('cleanup', 'max-images-age-hours'))
+        max_images_age = datetime.now(timezone.utc) - timedelta(hours=int(
+                                                                self.cfgGet('cleanup', 'max-images-age-hours')))
         for img_list in images.values():
             for i in range(0, len(img_list)):
                 img = img_list[i]

--- a/ocw/lib/azure.py
+++ b/ocw/lib/azure.py
@@ -146,7 +146,8 @@ class Azure(Provider):
             images[key].sort(key=lambda x: LooseVersion(x['build']))
 
         max_images_per_flavor = self.cfgGet('cleanup', 'max-images-per-flavor')
-        max_images_age = datetime.now(timezone.utc) - timedelta(hours=self.cfgGet('cleanup', 'max-images-age-hours'))
+        max_images_age = datetime.now(timezone.utc) - timedelta(hours=int(
+                                                                self.cfgGet('cleanup', 'max-images-age-hours')))
         for img_list in images.values():
             for i in range(0, len(img_list)):
                 img = img_list[i]

--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -119,7 +119,8 @@ class GCE(Provider):
             images[key].sort(key=lambda x: LooseVersion(x['build']))
 
         max_images_per_flavor = self.cfgGet('cleanup', 'max-images-per-flavor')
-        max_images_age = datetime.now(timezone.utc) - timedelta(hours=self.cfgGet('cleanup', 'max-images-age-hours'))
+        max_images_age = datetime.now(timezone.utc) - timedelta(hours=int(
+                                                                self.cfgGet('cleanup', 'max-images-age-hours')))
         for img_list in images.values():
             for i in range(0, len(img_list)):
                 img = img_list[i]


### PR DESCRIPTION
Fix this exception:

```
Traceback (most recent call last):
  File "./ocw/lib/cleanup.py", line 20, in cleanup_run
    Azure(vault_namespace).cleanup_all()
  File "./ocw/lib/azure.py", line 97, in cleanup_all
    self.cleanup_sle_images_container(block_blob_service, c)
  File "./ocw/lib/azure.py", line 149, in cleanup_sle_images_container
    max_images_age = datetime.now(timezone.utc) - timedelta(hours=self.cfgGet('cleanup', 'max-images-age-hours'))
TypeError: unsupported type for timedelta hours component: str
```