### PR TITLE
Fix: max_images_per_flavor usage, treat as int

### DIFF
--- a/ocw/lib/EC2.py
+++ b/ocw/lib/EC2.py
@@ -113,8 +113,7 @@ class EC2(Provider):
             images[key].sort(key=lambda x: LooseVersion(x['build']))
 
         max_images_per_flavor = self.cfgGet('cleanup', 'max-images-per-flavor')
-        max_images_age = datetime.now(timezone.utc) - timedelta(hours=int(
-                                                                self.cfgGet('cleanup', 'max-images-age-hours')))
+        max_images_age = datetime.now(timezone.utc) - timedelta(hours=self.cfgGet('cleanup', 'max-images-age-hours'))
         for img_list in images.values():
             for i in range(0, len(img_list)):
                 img = img_list[i]

--- a/ocw/lib/azure.py
+++ b/ocw/lib/azure.py
@@ -146,8 +146,7 @@ class Azure(Provider):
             images[key].sort(key=lambda x: LooseVersion(x['build']))
 
         max_images_per_flavor = self.cfgGet('cleanup', 'max-images-per-flavor')
-        max_images_age = datetime.now(timezone.utc) - timedelta(hours=int(
-                                                                self.cfgGet('cleanup', 'max-images-age-hours')))
+        max_images_age = datetime.now(timezone.utc) - timedelta(hours=self.cfgGet('cleanup', 'max-images-age-hours'))
         for img_list in images.values():
             for i in range(0, len(img_list)):
                 img = img_list[i]

--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -119,8 +119,7 @@ class GCE(Provider):
             images[key].sort(key=lambda x: LooseVersion(x['build']))
 
         max_images_per_flavor = self.cfgGet('cleanup', 'max-images-per-flavor')
-        max_images_age = datetime.now(timezone.utc) - timedelta(hours=int(
-                                                                self.cfgGet('cleanup', 'max-images-age-hours')))
+        max_images_age = datetime.now(timezone.utc) - timedelta(hours=self.cfgGet('cleanup', 'max-images-age-hours'))
         for img_list in images.values():
             for i in range(0, len(img_list)):
                 img = img_list[i]

--- a/ocw/lib/provider.py
+++ b/ocw/lib/provider.py
@@ -19,6 +19,6 @@ class Provider:
         e = mapping[key]
         namespace_section = '{}.namespace.{}'.format(section, self.__namespace)
         cfg = ConfigFile()
-        return cfg.get(
+        return type(e['default'])(cfg.get(
                 [namespace_section, field],
-                cfg.get([section, field], e['default']))
+                cfg.get([section, field], e['default'])))

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,54 @@
+from ocw.lib.provider import Provider
+from pathlib import Path, PurePath
+import webui
+
+working_dir = Path(PurePath(Path(__file__).absolute()).parent)
+webui.settings.CONFIG_FILE = working_dir / 'pcw_test_provider.ini'
+
+
+def set_pcw_ini(add=''):
+    with open(webui.settings.CONFIG_FILE, "w") as f:
+        f.write(add)
+
+
+def test_cfgGet_with_defaults():
+    set_pcw_ini()
+    provider = Provider('testns')
+    assert provider.cfgGet('cleanup', 'max-images-per-flavor') == 1
+    assert type(provider.cfgGet('cleanup', 'max-images-per-flavor')) is int
+    assert provider.cfgGet('cleanup', 'azure-storage-resourcegroup') == 'openqa-upload'
+    assert type(provider.cfgGet('cleanup', 'azure-storage-resourcegroup')) is str
+
+
+def test_cfgGet_from_pcw_ini():
+    set_pcw_ini("""
+[cleanup]
+max-images-per-flavor = 666
+azure-storage-resourcegroup = bla-blub
+""")
+    provider = Provider('testns')
+    assert provider.cfgGet('cleanup', 'max-images-per-flavor') == 666
+    assert type(provider.cfgGet('cleanup', 'max-images-per-flavor')) is int
+    assert provider.cfgGet('cleanup', 'azure-storage-resourcegroup') == 'bla-blub'
+    assert type(provider.cfgGet('cleanup', 'azure-storage-resourcegroup')) is str
+
+
+def test_cfgGet_from_pcw_ini_with_namespace():
+    set_pcw_ini("""
+[cleanup]
+max-images-per-flavor = 666
+azure-storage-resourcegroup = bla-blub
+
+[cleanup.namespace.testns]
+max-images-per-flavor = 42
+azure-storage-resourcegroup = bla-blub-ns
+""")
+    provider = Provider('testns')
+    assert provider.cfgGet('cleanup', 'max-images-per-flavor') == 42
+    assert type(provider.cfgGet('cleanup', 'max-images-per-flavor')) is int
+    assert provider.cfgGet('cleanup', 'azure-storage-resourcegroup') == 'bla-blub-ns'
+    assert type(provider.cfgGet('cleanup', 'azure-storage-resourcegroup')) is str
+
+
+def test_cleanup_pcw_ini():
+    Path(webui.settings.CONFIG_FILE).unlink()

--- a/webui/settings.py
+++ b/webui/settings.py
@@ -1,5 +1,8 @@
 import configparser
 import re
+import os
+import hashlib
+import logging.config
 
 """
 Django settings for webui project.
@@ -12,9 +15,6 @@ https://docs.djangoproject.com/en/2.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.1/ref/settings/
 """
-
-import os
-import logging.config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -165,7 +165,7 @@ logging.config.dictConfig({
 
 class ConfigFile:
     __instance = None
-    __file_mtime = None
+    __file_hash = None
     filename = None
     config = None
 
@@ -175,9 +175,17 @@ class ConfigFile:
         ConfigFile.__instance.filename = filename or CONFIG_FILE
         return ConfigFile.__instance
 
+    def get_hash(self):
+        with open(self.filename, 'r') as f:
+            h = hashlib.sha256()
+            h.update(f.read().encode('utf-8'))
+            return h.hexdigest()
+        return None
+
     def check_file(self):
-        if self.__file_mtime is None or self.__file_mtime != os.path.getmtime(self.filename):
-            self.__file_mtime = os.path.getmtime(self.filename)
+        file_hash = self.get_hash()
+        if self.__file_hash is None or self.__file_hash != file_hash:
+            self.__file_hash = file_hash
             self.config = configparser.ConfigParser()
             self.config.read(self.filename)
 


### PR DESCRIPTION
This avoid following error messages:
```
Traceback (most recent call last):
  File "./ocw/lib/cleanup.py", line 23, in cleanup_run
    EC2(vault_namespace).cleanup_all()
  File "./ocw/lib/EC2.py", line 121, in cleanup_all
    if (i < len(img_list) - max_images_per_flavor or img['creation_datetime'] < max_images_age):
TypeError: unsupported operand type(s) for -: 'int' and 'str'
```