### PR TITLE
Fix cleanup images - new image names

### DIFF
--- a/ocw/lib/cleanup.py
+++ b/ocw/lib/cleanup.py
@@ -16,6 +16,7 @@ def cleanup_run():
         try:
             providers = cfg.getList(['vault.namespace.{}'.format(vault_namespace), 'providers'],
                                     ['ec2', 'azure', 'gce'])
+            logger.debug("[{}] Run cleanup for {}".format(vault_namespace, ','.join(providers)))
             if 'azure' in providers:
                 Azure(vault_namespace).cleanup_all()
 
@@ -26,7 +27,7 @@ def cleanup_run():
                 GCE(vault_namespace).cleanup_all()
 
         except Exception as e:
-            logger.exception("Cleanup failed!")
+            logger.exception("[{}] Cleanup failed!".format(vault_namespace))
             send_mail(type(e).__name__ + ' on Cleanup', traceback.format_exc())
 
 

--- a/ocw/lib/provider.py
+++ b/ocw/lib/provider.py
@@ -1,4 +1,5 @@
 from webui.settings import ConfigFile
+import re
 
 
 class Provider:
@@ -22,3 +23,15 @@ class Provider:
         return type(e['default'])(cfg.get(
                 [namespace_section, field],
                 cfg.get([section, field], e['default'])))
+
+    def parse_image_name_helper(self, img_name, regex_s, group_key=['version', 'flavor', 'type', 'arch'],
+                                group_build=['kiwi', 'build']):
+        for regex in regex_s:
+            m = re.match(regex, img_name)
+            if m:
+                gdict = m.groupdict()
+                return {
+                    'key': '-'.join([gdict[k] for k in group_key if k in gdict and gdict[k] is not None]),
+                    'build': "-".join([gdict[k] for k in group_build if k in gdict and gdict[k] is not None]),
+                    }
+        return None

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -1,0 +1,29 @@
+from ocw.lib.azure import Azure
+from webui.settings import ConfigFile
+
+
+def test_parse_image_name(monkeypatch):
+    monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: True)
+    monkeypatch.setattr(ConfigFile, 'get', lambda *args, **kwargs: "FOOF")
+    az = Azure('fake')
+
+    assert az.parse_image_name('SLES12-SP5-Azure.x86_64-0.9.1-SAP-BYOS-Build3.3.vhd') == {
+            'key': '12-SP5-SAP-BYOS-x86_64',
+            'build': '0.9.1-3.3'
+            }
+
+    assert az.parse_image_name('SLES15-SP2-BYOS.x86_64-0.9.3-Azure-Build1.10.vhd') == {
+            'key': '15-SP2-Azure-BYOS-x86_64',
+            'build': '0.9.3-1.10'
+            }
+    assert az.parse_image_name('SLES15-SP2.x86_64-0.9.3-Azure-Basic-Build1.11.vhd') == {
+            'key': '15-SP2-Azure-Basic-x86_64',
+            'build': '0.9.3-1.11'
+            }
+
+    assert az.parse_image_name('SLES15-SP2-SAP-BYOS.x86_64-0.9.2-Azure-Build1.9.vhd') == {
+            'key': '15-SP2-Azure-SAP-BYOS-x86_64',
+            'build': '0.9.2-1.9'
+            }
+
+    assert az.parse_image_name('do not match') is None

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,0 +1,33 @@
+from ocw.lib.EC2 import EC2
+from webui.settings import ConfigFile
+
+
+def test_parse_image_name(monkeypatch):
+    monkeypatch.setattr(EC2, 'check_credentials', lambda *args, **kwargs: True)
+    monkeypatch.setattr(ConfigFile, 'get', lambda *args, **kwargs: "FOOF")
+    ec2 = EC2('fake')
+
+    assert ec2.parse_image_name('openqa-SLES12-SP5-EC2.x86_64-0.9.1-BYOS-Build1.55.raw.xz') == {
+            'key': '12-SP5-EC2-BYOS-x86_64',
+            'build': '0.9.1-1.55'
+            }
+    assert ec2.parse_image_name('openqa-SLES15-SP2.x86_64-0.9.3-EC2-HVM-Build1.10.raw.xz') == {
+            'key': '15-SP2-EC2-HVM-x86_64',
+            'build': '0.9.3-1.10'
+            }
+    assert ec2.parse_image_name('openqa-SLES15-SP2-BYOS.x86_64-0.9.3-EC2-HVM-Build1.10.raw.xz') == {
+            'key': '15-SP2-EC2-HVM-BYOS-x86_64',
+            'build': '0.9.3-1.10'
+            }
+
+    assert ec2.parse_image_name('openqa-SLES15-SP2.aarch64-0.9.3-EC2-HVM-Build1.49.raw.xz') == {
+            'key': '15-SP2-EC2-HVM-aarch64',
+            'build': '0.9.3-1.49'
+            }
+
+    assert ec2.parse_image_name('openqa-SLES12-SP4-EC2-HVM-BYOS.x86_64-0.9.2-Build2.56.raw.xz') == {
+            'key': '12-SP4-EC2-HVM-BYOS-x86_64',
+            'build': '0.9.2-2.56'
+            }
+
+    assert ec2.parse_image_name('do not match') is None

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -1,0 +1,24 @@
+from ocw.lib.gce import GCE
+from webui.settings import ConfigFile
+
+
+def test_parse_image_name(monkeypatch):
+    monkeypatch.setattr(ConfigFile, 'get', lambda *args, **kwargs: "FOOF")
+    gce = GCE('fake')
+
+    assert gce.parse_image_name('sles12-sp5-gce-x8664-0-9-1-byos-build1-56') == {
+            'key': '12-sp5-gce-byos-x8664',
+            'build': '0-9-1-1-56'
+            }
+
+    assert gce.parse_image_name('sles15-sp2-byos-x8664-0-9-3-gce-build1-10') == {
+            'key': '15-sp2-gce-byos-x8664',
+            'build': '0-9-3-1-10'
+            }
+
+    assert gce.parse_image_name('sles15-sp2-x8664-0-9-3-gce-build1-10') == {
+            'key': '15-sp2-gce-x8664',
+            'build': '0-9-3-1-10'
+            }
+
+    assert gce.parse_image_name('do not match') is None


### PR DESCRIPTION
The naming scheme changed from publiccloud images. This patch adopt to
the latest one.