### PR TITLE
Fix: Force empty tags instead of None

### DIFF
--- a/ocw/lib/db.py
+++ b/ocw/lib/db.py
@@ -110,7 +110,7 @@ def ec2_to_local_instance(instance, vault_namespace, region):
 
 def azure_to_json(i):
     info = {
-        'tags': i.tags,
+        'tags': i.tags if i.tags else {},
         'name': i.name,
         'id': i.id,
         'type': i.type,


### PR DESCRIPTION
If azure resource group doesn't have tags, we force it to an empty dict
instead of None. This is the behavior for GCE and EC2 so we will have it
for azure as well.