### PR TITLE
Fix: Delete disk and images from upload resource group

### DIFF
--- a/ocw/lib/EC2.py
+++ b/ocw/lib/EC2.py
@@ -97,7 +97,7 @@ class EC2(Provider):
                               -
                               (?P<kiwi>\d+\.\d+\.\d+)
                               -
-                              (?P<flavor>EC2[-\w]+)
+                              (?P<flavor>EC2[-\w]*)
                               -Build
                               (?P<build>\d+\.\d+)
                               \.raw\.xz

--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -1,11 +1,10 @@
 from .vault import GCECredential
-from .provider import Provider
+from .provider import Provider, Image
 import googleapiclient.discovery
 from google.oauth2 import service_account
 from dateutil.parser import parse
 import re
 import logging
-from distutils.version import LooseVersion
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +108,7 @@ class GCE(Provider):
         return self.parse_image_name_helper(img_name, regexes)
 
     def cleanup_all(self):
-        images = dict()
+        images = list()
         request = self.compute_client().images().list(project=self.__project)
         while request is not None:
             response = request.execute()
@@ -120,36 +119,25 @@ class GCE(Provider):
                 # name:sles12-sp5-gce-x8664-0-9-1-byos-build1-56
                 m = self.parse_image_name(image['name'])
                 if m:
-                    key = m['key']
-                    if key not in images:
-                        images[key] = list()
-
+                    images.append(Image(image['name'], flavor=m['key'], build=m['build'],
+                                        date=parse(image['creationTimestamp'])))
                     logger.debug('[{}]Image {} is candidate for deletion with build {}'.format(
                         self.__credentials.namespace, image['name'], m['build']))
-                    images[key].append({
-                        'build': m['build'],
-                        'name': image['name'],
-                        'creation_datetime':  parse(image['creationTimestamp']),
-                    })
                 else:
                     logger.error("[{}] Unable to parse image name '{}'".format(
                         self.__credentials.namespace, image['name']))
 
             request = self.compute_client().images().list_next(previous_request=request, previous_response=response)
 
-        for key in images:
-            images[key].sort(key=lambda x: LooseVersion(x['build']), reverse=True)
+        keep_images = self.get_keeping_image_names(images)
 
-        for img_list in images.values():
-            for i in range(0, len(img_list)):
-                img = img_list[i]
-                if (self.needs_to_delete_image(i, img['creation_datetime'])):
-                    logger.info("[GCE] Delete image '{}'".format(img['name']))
-                    request = self.compute_client().images().delete(project=self.__project, image=img['name'])
-                    response = request.execute()
-                    if 'error' in response:
-                        for e in response['error']['errors']:
-                            logger.error(e['message'])
-                    if 'warnings' in response:
-                        for w in response['warnings']:
-                            logger.error(w['message'])
+        for img in [i for i in images if i.name not in keep_images]:
+            logger.info("Delete image '{}'".format(img.name))
+            request = self.compute_client().images().delete(project=self.__project, image=img.name)
+            response = request.execute()
+            if 'error' in response:
+                for e in response['error']['errors']:
+                    logger.error(e['message'])
+            if 'warnings' in response:
+                for w in response['warnings']:
+                    logger.warning(w['message'])

--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -93,7 +93,7 @@ class GCE(Provider):
             # sles15-sp2-x8664-0-9-3-gce-build1-10
             re.compile(r'''^sles
                     (?P<version>\d+(-sp\d+)?)
-                    (-(?P<type>\w+))?
+                    (-(?P<type>[-\w]+))?
                     -
                     (?P<arch>[^-]+)
                     -

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -15,7 +15,7 @@ class MockProperties:
 
 
 class MockImage:
-    def __init__(self, name, last_modified):
+    def __init__(self, name, last_modified=None):
         self.name = name
         self.properties = MockProperties(last_modified)
 

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -2,9 +2,11 @@ from ocw.lib.azure import Azure
 from ocw.lib.provider import Provider
 from webui.settings import ConfigFile
 from azure.storage.blob import BlockBlobService
+from datetime import datetime, timezone, timedelta
 from .generators import MockImage
 from .generators import generate_mocked_images_older_than
 from .generators import mock_cfgGet
+from tests import generators
 
 
 delete_calls = {'quantity': [], 'old': [], 'young': []}
@@ -15,12 +17,14 @@ def delete_blob_mock(self, container_name, img_name, snapshot=None):
 
 
 def list_blobs_mock(self, container_name):
-    if container_name == 'quantity':
-        return generate_mocked_images_older_than(8)
-    elif container_name == 'old':
-        return generate_mocked_images_older_than(25)
-    else:
-        return generate_mocked_images_older_than(1)
+    last_modified = datetime.now()
+    return [MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd'),
+            MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd'),
+            MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.7.vhd'),
+            MockImage('SLES15-SP2-BYOS.x86_64-0.9.3-Azure-Build2.36.vhd', last_modified),
+            MockImage('SLES15-SP2-BYOS.x86_64-0.9.6-Azure-Build1.3.vhd', last_modified),
+            MockImage('SLES15-SP2-BYOS.x86_64-0.9.6-Azure-Build1.9.vhd', last_modified)
+            ]
 
 
 def test_parse_image_name(monkeypatch):
@@ -58,37 +62,178 @@ def test_parse_image_name(monkeypatch):
     assert az.parse_image_name('do not match') is None
 
 
-def test_cleanup_sle_images_container_too_many(monkeypatch):
-    test_name = 'quantity'
+def test_cleanup_sle_images_container(monkeypatch):
+    class FakeBlockBlobService:
+        deleted_blobs = list()
+
+        def list_blobs(self, container):
+            return [
+                    MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd'),
+                    MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd'),
+                    MockImage('YouWillNotGetMyBuildNumber'),
+                ]
+
+        def delete_blob(self, container_name, img_name,  snapshot):
+            self.deleted_blobs.append(img_name)
+
     monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: True)
-    monkeypatch.setattr(BlockBlobService, 'list_blobs', list_blobs_mock)
-    monkeypatch.setattr(BlockBlobService, 'delete_blob', delete_blob_mock)
     monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
     az = Azure('fake')
-    az.cleanup_sle_images_container(BlockBlobService(account_name='openqa', account_key='www'), test_name)
-    assert delete_calls[test_name] == ['SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd',
-                                       'SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd',
-                                       'SLES15-SP2-BYOS.x86_64-0.9.6-Azure-Build1.3.vhd',
-                                       'SLES15-SP2-BYOS.x86_64-0.9.3-Azure-Build2.36.vhd']
+    bbsrv = FakeBlockBlobService()
+    keep_images = ['SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd']
+
+    az.cleanup_sle_images_container(bbsrv, keep_images)
+    assert bbsrv.deleted_blobs == ['SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd']
 
 
-def test_cleanup_sle_images_container_too_young(monkeypatch):
-    test_name = 'young'
-    monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: True)
-    monkeypatch.setattr(BlockBlobService, 'list_blobs', list_blobs_mock)
-    monkeypatch.setattr(BlockBlobService, 'delete_blob', delete_blob_mock)
+def test_cleanup_images_from_rg(monkeypatch):
+    deleted_images = list()
+    items = [
+            MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd'),
+            MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd'),
+            MockImage('YouWillNotGetMyBuildNumber'),
+            ]
+
+    def mock_res_mgmt_client(self):
+        def res_mgmt_client():
+            pass
+        res_mgmt_client.resources = lambda: None
+        res_mgmt_client.resources.list_by_resource_group = lambda *args, **kwargs: items
+        return res_mgmt_client
+
+    def mock_compute_mgmt_client(self):
+        def compute_mgmt_client():
+            pass
+        compute_mgmt_client.images = lambda: None
+        compute_mgmt_client.images.delete = lambda rg, name: deleted_images.append(name)
+        return compute_mgmt_client
+
     monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
-    az = Azure('fake')
-    az.cleanup_sle_images_container(BlockBlobService(account_name='openqa', account_key='www'), test_name)
-    assert len(delete_calls[test_name]) == 0
-
-
-def test_cleanup_sle_images_container_too_old(monkeypatch):
-    test_name = 'old'
     monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: True)
-    monkeypatch.setattr(BlockBlobService, 'list_blobs', list_blobs_mock)
-    monkeypatch.setattr(BlockBlobService, 'delete_blob', delete_blob_mock)
-    monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
+    monkeypatch.setattr(Azure, 'resource_mgmt_client', mock_res_mgmt_client)
+    monkeypatch.setattr(Azure, 'compute_mgmt_client', mock_compute_mgmt_client)
+
     az = Azure('fake')
-    az.cleanup_sle_images_container(BlockBlobService(account_name='openqa', account_key='www'), test_name)
-    assert len(delete_calls[test_name]) == 6
+    keep_images = ['SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd']
+    az.cleanup_images_from_rg(keep_images)
+    assert deleted_images == ['SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd']
+
+
+def test_cleanup_disks_from_rg(monkeypatch):
+    deleted_disks = list()
+
+    items = [
+            MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd'),
+            MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd'),
+            MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.7.vhd'),
+            MockImage('YouWillNotGetMyBuildNumber'),
+            ]
+
+    def mock_res_mgmt_client(self):
+        def res_mgmt_client():
+            pass
+        res_mgmt_client.resources = lambda: None
+        res_mgmt_client.resources.list_by_resource_group = lambda *args, **kwargs: items
+        return res_mgmt_client
+
+    def mock_compute_mgmt_client(self):
+        class FakeDisk:
+            def __init__(self, rg, name):
+                self.managed_by = name == 'SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd'
+
+        def compute_mgmt_client():
+            pass
+        compute_mgmt_client.disks = lambda: None
+        compute_mgmt_client.disks.get = lambda rg, name: FakeDisk(rg, name)
+        compute_mgmt_client.disks.delete = lambda rg, name: deleted_disks.append(name)
+        return compute_mgmt_client
+
+    monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
+    monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: True)
+    monkeypatch.setattr(Azure, 'resource_mgmt_client', mock_res_mgmt_client)
+    monkeypatch.setattr(Azure, 'compute_mgmt_client', mock_compute_mgmt_client)
+
+    keep_images = ['SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd']
+    az = Azure('fake')
+    az.cleanup_disks_from_rg(keep_images)
+    assert deleted_disks == ['SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.7.vhd']
+
+
+def test_get_keeping_image_names(monkeypatch):
+    class FakeBlockBlobService:
+        def list_blobs(self, container):
+            older_then_min_age = datetime.now(timezone.utc) - timedelta(hours=generators.min_image_age_hours+1)
+            return [
+                    MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.0-Build1.43.vhd', older_then_min_age),
+                    MockImage('SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd', older_then_min_age),
+                    MockImage('YouWillNotGetMyBuildNumber', older_then_min_age),
+                    ]
+
+    monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
+    monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: True)
+
+    az = Azure('fake')
+    generators.max_images_per_flavor = 1
+    assert az.get_keeping_image_names(FakeBlockBlobService()) == ['SLES15-SP2-Azure-HPC.x86_64-0.9.1-Build1.3.vhd']
+
+
+def test_cleanup_all(monkeypatch):
+    called = 0
+
+    def count_call(*args, **kwargs):
+        nonlocal called
+        called = called + 1
+
+    monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
+    monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: None)
+    monkeypatch.setattr(Azure, 'get_storage_key', lambda *args, **kwargs: 'FOOXX')
+    monkeypatch.setattr(Azure, 'get_keeping_image_names', lambda *args, **kwargs: ['a', 'b'])
+    monkeypatch.setattr(Azure, 'cleanup_sle_images_container', count_call)
+    monkeypatch.setattr(Azure, 'cleanup_disks_from_rg', count_call)
+    monkeypatch.setattr(Azure, 'cleanup_images_from_rg', count_call)
+    monkeypatch.setattr(Azure, 'cleanup_bootdiagnostics', count_call)
+
+    az = Azure('fake')
+    az.cleanup_all()
+    assert called == 4
+
+
+def test_cleanup_bootdiagnostics(monkeypatch):
+    class FakeBlockBlobService:
+        deleted_container = list()
+
+        def list_containers(self):
+            older_then_min_age = datetime.now(timezone.utc) - timedelta(hours=generators.min_image_age_hours+1)
+            newer_then_min_age = datetime.now(timezone.utc)
+            return [
+                    MockImage('bootdiagnostics-A', older_then_min_age),
+                    MockImage('bootdiagnostics-B', older_then_min_age),
+                    MockImage('bootdiagnostics-C', newer_then_min_age),
+                    MockImage('bootdiagnostics-D', newer_then_min_age),
+                    MockImage('bootdiagnostics-E', older_then_min_age),
+                ]
+
+        def list_blobs(self, container):
+            older_then_min_age = datetime.now(timezone.utc) - timedelta(hours=generators.min_image_age_hours+1)
+            newer_then_min_age = datetime.now(timezone.utc)
+            last_modified = older_then_min_age
+
+            if (container == 'bootdiagnostics-E'):
+                last_modified = newer_then_min_age
+
+            return [MockImage('blalbub', last_modified)]
+
+        def delete_container(self, container_name):
+            self.deleted_container.append(container_name)
+
+    monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
+    monkeypatch.setattr(Azure, 'check_credentials', lambda *args, **kwargs: True)
+    bbs = FakeBlockBlobService()
+
+    az = Azure('fake')
+    az.cleanup_bootdiagnostics(bbs)
+
+    assert bbs.deleted_container == [
+            'bootdiagnostics-A',
+            'bootdiagnostics-B',
+            ]

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,5 +1,9 @@
 from ocw.lib.EC2 import EC2
+from ocw.lib.provider import Provider
 from webui.settings import ConfigFile
+from tests.generators import mock_cfgGet
+from tests.generators import min_image_age_hours, max_image_age_hours
+from datetime import datetime, timezone, timedelta
 
 
 def test_parse_image_name(monkeypatch):
@@ -31,3 +35,53 @@ def test_parse_image_name(monkeypatch):
             }
 
     assert ec2.parse_image_name('do not match') is None
+
+
+def test_cleanup_all(monkeypatch):
+    newer_then_min_age = datetime.now(timezone.utc).isoformat()
+    older_then_min_age = (datetime.now(timezone.utc) - timedelta(hours=min_image_age_hours+1)).isoformat()
+    older_then_max_age = (datetime.now(timezone.utc) - timedelta(hours=max_image_age_hours+1)).isoformat()
+
+    response = {
+            'Images': [
+                {'Name': 'SomeThingElse',
+                    'CreationDate': older_then_max_age, 'id': 0},
+                {'Name': 'openqa-SLES15-SP2-BYOS.x86_64-0.9.3-EC2-HVM-Build1.10.raw.xz',
+                    'CreationDate': newer_then_min_age, 'id': 1},
+                {'Name': 'openqa-SLES15-SP2-BYOS.x86_64-0.9.3-EC2-HVM-Build1.11.raw.xz',
+                    'CreationDate': older_then_min_age, 'id': 2},
+                {'Name': 'openqa-SLES15-SP2-BYOS.x86_64-0.9.3-EC2-HVM-Build1.12.raw.xz',
+                    'CreationDate': older_then_min_age, 'id': 3},
+                {'Name': 'openqa-SLES15-SP2-BYOS.x86_64-0.9.3-EC2-HVM-Build1.13.raw.xz',
+                    'CreationDate': older_then_max_age, 'id': 4},
+                ]
+            }
+    deleted_images = list()
+
+    def mocked_ec2_client():
+        pass
+    mocked_ec2_client.describe_images = lambda *args, **kwargs: response
+    mocked_ec2_client.deregister_image = lambda *args, **kwargs: deleted_images.append(kwargs['ImageId'])
+
+    monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
+    monkeypatch.setattr(EC2, 'check_credentials', lambda *args, **kwargs: True)
+    monkeypatch.setattr(EC2, 'ec2_client', lambda self: mocked_ec2_client)
+
+    ec2 = EC2('fake')
+    ec2.cleanup_all()
+
+    assert deleted_images == [2, 3, 4]
+
+    deleted_images = list()
+    response = {
+            'Images': [
+                {'Name': 'openqa-SLES15-SP2-BYOS.x86_64-0.9.3-EC2-HVM-Build1.12.raw.xz',
+                    'CreationDate': older_then_min_age, 'id': 3},
+                {'Name': 'openqa-SLES15-SP2-BYOS.x86_64-0.9.3-EC2-HVM-Build1.13.raw.xz',
+                    'CreationDate': older_then_min_age, 'id': 4},
+                ]
+            }
+    ec2.cleanup_all()
+    assert deleted_images == [3]
+
+

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -34,6 +34,11 @@ def test_parse_image_name(monkeypatch):
             'build': '0.9.2-2.56'
             }
 
+    assert ec2.parse_image_name('openqa-SLES15-SP2-CHOST-BYOS.x86_64-0.9.3-EC2-Build1.11.raw.xz') == {
+            'key': '15-SP2-EC2-CHOST-BYOS-x86_64',
+            'build': '0.9.3-1.11'
+            }
+
     assert ec2.parse_image_name('do not match') is None
 
 

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -26,6 +26,11 @@ def test_parse_image_name(monkeypatch):
             'build': '0-9-3-1-10'
             }
 
+    assert gce.parse_image_name('sles15-sp2-chost-byos-x8664-0-9-3-gce-build1-11') == {
+            'key': '15-sp2-gce-chost-byos-x8664',
+            'build': '0-9-3-1-11'
+            }
+
     assert gce.parse_image_name('do not match') is None
 
 

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -1,5 +1,10 @@
 from ocw.lib.gce import GCE
+from ocw.lib.provider import Provider
 from webui.settings import ConfigFile
+from tests.generators import min_image_age_hours, max_image_age_hours
+from tests.generators import mock_cfgGet
+from tests import generators
+from datetime import datetime, timezone, timedelta
 
 
 def test_parse_image_name(monkeypatch):
@@ -22,3 +27,69 @@ def test_parse_image_name(monkeypatch):
             }
 
     assert gce.parse_image_name('do not match') is None
+
+
+class FakeRequest:
+    def __init__(self, response={}):
+        self.response = response
+
+    def execute(self):
+        return self.response
+
+
+class FakeMockImages:
+
+    def __init__(self, responses):
+        self.deleted = list()
+        self.responses = responses
+
+    def list(self, *args, **kwargs):
+        return self.responses.pop(0)
+
+    def list_next(self, *args, **kwargs):
+        return self.responses.pop(0)
+
+    def delete(self, *args, **kwargs):
+        self.deleted.append(kwargs['image'])
+        return self.responses.pop(0)
+
+
+def test_cleanup_all(monkeypatch):
+    newer_then_min_age = datetime.now(timezone.utc).isoformat()
+    older_then_min_age = (datetime.now(timezone.utc) - timedelta(hours=min_image_age_hours+1)).isoformat()
+    older_then_max_age = (datetime.now(timezone.utc) - timedelta(hours=max_image_age_hours+1)).isoformat()
+
+    fmi = FakeMockImages([
+        FakeRequest({   # on images().list()
+            'items': [
+                {'name': 'I will not be parsed', 'creationTimestamp': older_then_max_age},
+                {'name': 'sles12-sp5-gce-x8664-0-9-1-byos-build1-54', 'creationTimestamp': newer_then_min_age},
+                {'name': 'sles12-sp5-gce-x8664-0-9-1-byos-build1-56', 'creationTimestamp': older_then_min_age}
+            ]
+        }),
+        FakeRequest({   # on images().list_next()
+            'items': [
+                {'name': 'sles12-sp5-gce-x8664-0-9-1-byos-build1-57', 'creationTimestamp': older_then_min_age},
+                {'name': 'sles12-sp5-gce-x8664-0-9-1-byos-build1-58', 'creationTimestamp': older_then_max_age}
+            ]
+        }),
+        None,   # on images().list_next()
+        FakeRequest({'error': {'errors': [{'message': 'err message'}]}, 'warnings': [{'message': 'warning message'}]}),
+        FakeRequest(),    # on images().delete()
+        ])
+
+    def mocked_compute_client():
+        pass
+    mocked_compute_client.images = lambda *args, **kwargs: fmi
+    monkeypatch.setattr(GCE, 'compute_client', lambda self: mocked_compute_client)
+
+    monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
+
+    gce = GCE('fake')
+    generators.max_images_per_flavor = 2
+    gce.cleanup_all()
+    assert fmi.deleted == ['sles12-sp5-gce-x8664-0-9-1-byos-build1-56', 'sles12-sp5-gce-x8664-0-9-1-byos-build1-58']
+
+    fmi = FakeMockImages([FakeRequest({})])
+    gce.cleanup_all()
+    assert fmi.deleted == []


### PR DESCRIPTION
With this patch, we cleanup the disk and image resources from
a resource group specified with azure-storage-resourcegroup in pcw.ini

The cleanup rules for images still apply here.