### PR TITLE
Add cleanup CLI command

### DIFF
--- a/ocw/lib/emailnotify.py
+++ b/ocw/lib/emailnotify.py
@@ -7,13 +7,13 @@ from django.urls import reverse
 import json
 import smtplib
 import logging
-from ocw import views
 
 logger = logging.getLogger(__name__)
 
 
 def draw_instance_table(objects):
 
+    from ocw import views
     table = Texttable(max_width=0)
     table.set_deco(Texttable.HEADER)
     table.header(['Provider', 'id', 'Created-By', 'Namespace', 'Age', 'Delete'])

--- a/ocw/management/commands/cleanup.py
+++ b/ocw/management/commands/cleanup.py
@@ -1,0 +1,9 @@
+from django.core.management.base import BaseCommand
+from ocw.lib.cleanup import cleanup_run
+
+
+class Command(BaseCommand):
+    help = 'Delete all leftovers in all providers (according to pcw.ini)'
+
+    def handle(self, *args, **options):
+        cleanup_run()


### PR DESCRIPTION
It is now possible to run `python manage.py cleanup`. This will
internally call the function `ocw.lib.cleanup.cleanup_all()`.