### PR TITLE
ec2: delete_instance should handle case when instance was deleted outside

### DIFF
--- a/ocw/lib/EC2.py
+++ b/ocw/lib/EC2.py
@@ -85,7 +85,11 @@ class EC2(Provider):
         return regions
 
     def delete_instance(self, instance_id):
-        self.ec2_resource().instances.filter(InstanceIds=[instance_id]).terminate()
+        instances_list = list(self.ec2_resource().instances.filter(InstanceIds=[instance_id]))
+        if len(instances_list) > 0:
+            instances_list[0].terminate()
+        else:
+            logger.warning("Instance {} is ACTIVE in local DB but does not exists on EC2".format(instance_id))
 
     def parse_image_name(self, img_name):
         regexes = [


### PR DESCRIPTION
Before this patch code was acting from perspective that instance could not be deleted by 3d parties
or human. But sometimes this happens so new code will correctly handle this