### PR TITLE
ec2: loop over all regions during cleanup

### DIFF
--- a/ocw/lib/db.py
+++ b/ocw/lib/db.py
@@ -165,8 +165,6 @@ def gce_to_local_instance(instance, vault_namespace):
 
 
 def _update_provider(name, vault_namespace):
-    cfg = ConfigFile()
-
     if 'azure' in name:
         instances = Azure(vault_namespace).list_resource_groups()
         instances = [azure_to_local_instance(i, vault_namespace) for i in instances]
@@ -175,7 +173,7 @@ def _update_provider(name, vault_namespace):
 
     if 'ec2' in name:
         instances = []
-        for region in cfg.getList(['ec2', 'regions'], EC2(vault_namespace).all_regions()):
+        for region in EC2(vault_namespace).all_regions:
             instances_csp = EC2(vault_namespace).list_instances(region=region)
             instances += [ec2_to_local_instance(i, vault_namespace, region) for i in instances_csp]
             logger.info("Got %d instances from EC2 in region %s", len(instances), region)
@@ -242,7 +240,7 @@ def delete_instance(instance):
     if (instance.provider == ProviderChoice.AZURE):
         Azure(instance.vault_namespace).delete_resource(instance.instance_id)
     elif (instance.provider == ProviderChoice.EC2):
-        EC2(instance.vault_namespace).delete_instance(instance.instance_id)
+        EC2(instance.vault_namespace).delete_instance(instance.region, instance.instance_id)
     elif (instance.provider == ProviderChoice.GCE):
         GCE(instance.vault_namespace).delete_instance(instance.instance_id, instance.region)
     else:

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 
 def test_parse_image_name(monkeypatch):
     monkeypatch.setattr(EC2, 'check_credentials', lambda *args, **kwargs: True)
+    monkeypatch.setattr(EC2, 'get_all_regions', lambda self:['region1','region2'])
     monkeypatch.setattr(ConfigFile, 'get', lambda *args, **kwargs: "FOOF")
     ec2 = EC2('fake')
 
@@ -71,7 +72,8 @@ def test_cleanup_images(monkeypatch):
 
     monkeypatch.setattr(Provider, 'cfgGet', mock_cfgGet)
     monkeypatch.setattr(EC2, 'check_credentials', lambda *args, **kwargs: True)
-    monkeypatch.setattr(EC2, 'ec2_client', lambda self: mocked_ec2_client)
+    monkeypatch.setattr(EC2, 'get_all_regions', lambda self:['region1'])
+    monkeypatch.setattr(EC2, 'ec2_client', lambda self, region: mocked_ec2_client)
 
     ec2 = EC2('fake')
     ec2.cleanup_images()
@@ -125,7 +127,7 @@ def test_cleanup_snapshots(monkeypatch):
     monkeypatch.setattr(EC2, 'check_credentials', lambda *args, **kwargs: True)
     monkeypatch.setattr(EC2, 'needs_to_delete_snapshot', lambda *args, **kwargs: True)
     monkeypatch.setattr(EC2, 'ec2_client', lambda self, region: mocked_ec2_client)
-    monkeypatch.setattr(EC2, 'all_regions', lambda self: ['eu-central'])
+    monkeypatch.setattr(EC2, 'get_all_regions', lambda self: ['eu-central'])
 
     mocked_ec2_client.describe_snapshots = lambda OwnerIds: response
     mocked_ec2_client.delete_snapshot = delete_snapshot


### PR DESCRIPTION
Before this patch EC2 was doing cleanup only in single region.
Now we looping over all available regions