### PR TITLE
cleanup: take providers from cleanup.namespace.

### DIFF
--- a/ocw/lib/cleanup.py
+++ b/ocw/lib/cleanup.py
@@ -16,7 +16,7 @@ def cleanup_run():
     if cfg.has('cleanup'):
         for vault_namespace in cfg.getList(['cleanup', 'namespaces'], cfg.getList(['vault', 'namespaces'], [''])):
             try:
-                providers = cfg.getList(['vault.namespace.{}'.format(vault_namespace), 'providers'],
+                providers = cfg.getList(['cleanup.namespace.{}'.format(vault_namespace), 'providers'],
                                         ['ec2', 'azure', 'gce'])
                 logger.debug("[{}] Run cleanup for {}".format(vault_namespace, ','.join(providers)))
                 if 'azure' in providers:


### PR DESCRIPTION
Before this patch we were taking providers from vault.namespace.<namespace_name>.
This patch changing this to logically expected cleanup.namespace.<namespace_name>